### PR TITLE
feat: MultipleLocalAuth agora passa a implementar a verificação de token nativa do MapaDaCultura

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -552,7 +552,7 @@ class Provider extends \MapasCulturais\AuthProvider {
         ];
 
         // validate captcha
-        if ((!isset($_POST["g-recaptcha-response"]) || empty($_POST["g-recaptcha-response"])) || !$app->verifyRecaptcha2($_POST['g-recaptcha-response'])) {
+        if ((!isset($_POST["g-recaptcha-response"]) || empty($_POST["g-recaptcha-response"])) || !$app->verifyCaptcha($_POST['g-recaptcha-response'])) {
             array_push($errors['captcha'], i::__('Captcha incorreto, tente novamente!', 'multipleLocal'));
             return [
                 'success' => false,
@@ -719,7 +719,7 @@ class Provider extends \MapasCulturais\AuthProvider {
             'sendEmail' => []
         ];
 
-        if ((!isset($_POST["g-recaptcha-response"]) || empty($_POST["g-recaptcha-response"])) || !$app->verifyRecaptcha2($_POST['g-recaptcha-response'])) {
+        if ((!isset($_POST["g-recaptcha-response"]) || empty($_POST["g-recaptcha-response"])) || !$app->verifyCaptcha($_POST['g-recaptcha-response'])) {
             array_push($errors['captcha'], i::__('Captcha incorreto, tente novamente!', 'multipleLocal'));
             return [
                 'success' => false,
@@ -1009,7 +1009,7 @@ class Provider extends \MapasCulturais\AuthProvider {
         ];
 
         // Se não recebemos o token, não há motivo para avançar para a verificação
-        if ((!isset($_POST["g-recaptcha-response"]) || empty($_POST["g-recaptcha-response"])) || !$app->verifyRecaptcha2($_POST['g-recaptcha-response'])) {
+        if ((!isset($_POST["g-recaptcha-response"]) || empty($_POST["g-recaptcha-response"])) || !$app->verifyCaptcha($_POST['g-recaptcha-response'])) {
             array_push($errors['captcha'], i::__('Captcha incorreto, tente novamente!', 'multipleLocal'));
             return [
                 'success' => false,

--- a/components/login-wizard/script.js
+++ b/components/login-wizard/script.js
@@ -24,7 +24,8 @@ app.component('login-wizard', {
             showPassword: false, // Adicionado para controlar a exibição do campo de senha
             passwordResetRequired: false,
             userNotFound: false,  // Certifique-se de que esta propriedade está definida
-            recaptchaShown: true  // Controle de visibilidade do reCAPTCHA
+            recaptchaShown: true,  // Controle de visibilidade do reCAPTCHA
+            error: false
         }
     },
 
@@ -186,20 +187,8 @@ app.component('login-wizard', {
         },
 
         throwErrors(errors) {
+            this.error = true;
             const messages = useMessages();
-
-            if (this.recaptchaResponse !== '') {
-                // check if grecaptcha is not defined
-                if (typeof grecaptcha !== 'undefined') {
-                    grecaptcha.reset();
-                    this.expiredCaptcha();
-                }
-
-                // check if turnstile is not defined
-                if (typeof window.turnstile !== 'undefined') {
-                    window.turnstile.reset();
-                }
-            }
 
             for (let key in errors) {
                 for (let val of errors[key]) {

--- a/components/login-wizard/script.js
+++ b/components/login-wizard/script.js
@@ -188,9 +188,17 @@ app.component('login-wizard', {
         throwErrors(errors) {
             const messages = useMessages();
 
-            if (this.recaptchaShown && this.recaptchaResponse !== '') {
-                grecaptcha.reset();
-                this.expiredCaptcha();
+            if (this.recaptchaResponse !== '') {
+                // check if grecaptcha is not defined
+                if (typeof grecaptcha !== 'undefined') {
+                    grecaptcha.reset();
+                    this.expiredCaptcha();
+                }
+
+                // check if turnstile is not defined
+                if (typeof window.turnstile !== 'undefined') {
+                    window.turnstile.reset();
+                }
             }
 
             for (let key in errors) {

--- a/components/login-wizard/script.js
+++ b/components/login-wizard/script.js
@@ -60,7 +60,7 @@ app.component('login-wizard', {
             }
 
             if(!this.recaptchaResponse || this.recaptchaResponse === '' || this.recaptchaResponse === null) {
-                this.throwErrors({ email: ['Por favor, preencha o ReCaptcha'] });
+                this.throwErrors({ email: ['Por favor, preencha o CAPTCHA'] });
                 return;
             }
     

--- a/components/login-wizard/template.php
+++ b/components/login-wizard/template.php
@@ -53,7 +53,7 @@ $this->import('
                     </div>
 
                     <!-- Componente responsável por renderizar o CAPTCHA -->
-                    <mc-captcha @captcha-verified="verifyCaptcha" @captcha-expired="expiredCaptcha"></mc-captcha>
+                    <mc-captcha @captcha-verified="verifyCaptcha" @captcha-expired="expiredCaptcha" :error="error"></mc-captcha>
 
                     <div class="login__buttons">
                         <button v-if="!showPassword && !passwordResetRequired && !userNotFound" class="button button--primary button--large button--md" type="submit"> <?= i::__('Próximo') ?> </button>

--- a/components/login-wizard/template.php
+++ b/components/login-wizard/template.php
@@ -10,6 +10,7 @@ use MapasCulturais\i;
 $this->import('
     mc-card
     password-strongness
+    mc-captcha
 ');
 ?>
 
@@ -51,7 +52,8 @@ $this->import('
 
                     </div>
 
-                    <VueRecaptcha v-if="configs['google-recaptcha-sitekey'] && !showPassword && !passwordResetRequired && !userNotFound" :sitekey="configs['google-recaptcha-sitekey']" @verify="verifyCaptcha" @expired="expiredCaptcha" @render="expiredCaptcha" class="g-recaptcha"></VueRecaptcha>
+                    <!-- Componente responsável por renderizar o captcha [Google | Turnstile] -->
+                    <mc-captcha @captcha-verified="verifyCaptcha" @captcha-expired="expiredCaptcha"></mc-captcha>
 
                     <div class="login__buttons">
                         <button v-if="!showPassword && !passwordResetRequired && !userNotFound" class="button button--primary button--large button--md" type="submit"> <?= i::__('Próximo') ?> </button>
@@ -86,7 +88,11 @@ $this->import('
                         <label for="email"> <?= i::__('E-mail') ?> </label>
                         <input type="email" name="email" id="email" v-model="email" autocomplete="off" />
                     </div>
-                    <VueRecaptcha v-if="configs['google-recaptcha-sitekey']" :sitekey="configs['google-recaptcha-sitekey']" @verify="verifyCaptcha" @expired="expiredCaptcha" @render="expiredCaptcha" class="g-recaptcha col-12"></VueRecaptcha>
+                    
+                    <!-- Componente responsável por renderizar o captcha [Google | Turnstile] -->
+                    <mc-captcha @captcha-verified="verifyCaptcha" @captcha-expired="expiredCaptcha" class="col-12"></mc-captcha>
+
+                    <!-- <VueRecaptcha v-if="configs['google-recaptcha-sitekey']" :sitekey="configs['google-recaptcha-sitekey']" @verify="verifyCaptcha" @expired="expiredCaptcha" @render="expiredCaptcha" class="g-recaptcha col-12"></VueRecaptcha> -->
                     <button class="col-12 button button--primary button--large button--md" type="submit"> <?= i::__('Receber instruções no e-mail') ?> </button>
                     <a @click="recoveryRequest = false" class="col-12 button button--secondarylight button--large button--md"> <?= i::__('Voltar') ?> </a>
                 </form>

--- a/components/login-wizard/template.php
+++ b/components/login-wizard/template.php
@@ -52,7 +52,7 @@ $this->import('
 
                     </div>
 
-                    <!-- Componente responsável por renderizar o captcha [Google | Turnstile] -->
+                    <!-- Componente responsável por renderizar o CAPTCHA -->
                     <mc-captcha @captcha-verified="verifyCaptcha" @captcha-expired="expiredCaptcha"></mc-captcha>
 
                     <div class="login__buttons">
@@ -89,7 +89,7 @@ $this->import('
                         <input type="email" name="email" id="email" v-model="email" autocomplete="off" />
                     </div>
                     
-                    <!-- Componente responsável por renderizar o captcha [Google | Turnstile] -->
+                    <!-- Componente responsável por renderizar o CAPTCHA -->
                     <mc-captcha @captcha-verified="verifyCaptcha" @captcha-expired="expiredCaptcha" class="col-12"></mc-captcha>
 
                     <!-- <VueRecaptcha v-if="configs['google-recaptcha-sitekey']" :sitekey="configs['google-recaptcha-sitekey']" @verify="verifyCaptcha" @expired="expiredCaptcha" @render="expiredCaptcha" class="g-recaptcha col-12"></VueRecaptcha> -->


### PR DESCRIPTION
# Cenário
Centralizar todo o carregamento do captcha em um componente para que seja possível configurar N providers, de forma que torne mais flexível o uso e implementação de Captcha no Mapa Da Cultura.

Assim o Plugin MultipleLocalAuth passa a utilizar:
- O componente nativo do MapaDaCultura (mc-captcha)
- A verificação de token implementada no Core Do MapaDaCultura

## Pontos importantes
Foi tomado cuidado para que essa centralização não afete aqueles que desejam manter às configurações anteriores.

## Telas afetadas:
- Login
- Cadastro
- Recuperação de Senha

Esta é uma implementação Codependente do [Pull Request 31](https://github.com/culturagovbr/mapadacultura/pull/31) realizado no MapaDaCultura