### PR TITLE
Implementa hook para permitir a personalização do template de e-mail de validação de conta

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -1252,12 +1252,15 @@ class Provider extends \MapasCulturais\AuthProvider {
         $mustache = new \Mustache_Engine();
         $site_name = $app->siteName;
         $baseUrl = $app->getBaseUrl();
+        $template_name = 'email-to-validate-account.html';
+
+        $app->applyHookBoundTo($this, 'auth.sendEmailValidation', [&$template_name]);
+
+        $template = $app->view->resolveFilename('views/auth', $template_name);
+
         $content = $mustache->render(
             file_get_contents(
-                __DIR__.
-                DIRECTORY_SEPARATOR.'views'.
-                DIRECTORY_SEPARATOR.'auth'.
-                DIRECTORY_SEPARATOR.'email-to-validate-account.html'
+               $template
             ), array(
                 "siteName" => $site_name,
                 "user" => $user->profile->name,


### PR DESCRIPTION
Implementa a criação de um hook no método `sendEmailValidation()` do arquivo `Provider.php`, permitindo a personalização do template template.html utilizado no e-mail de validação de conta. Essa alteração oferece maior flexibilidade para ajustes no conteúdo do e-mail durante o processo de validação de usuários. Exemplo de uso

```
$app->hook(function(&$template_name) {
    $template_name = "template-email.html";
});
```